### PR TITLE
Update deprecated XML namespace to current

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,12 @@
             <version>1.18.24</version>
             <scope>provided</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/jakarta.xml.bind/jakarta.xml.bind-api -->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>4.0.2</version>
+        </dependency>
 
         <!-- jUint 5 Tests -->
         <dependency>
@@ -73,7 +79,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>2.2.1</version>
+                    <version>3.3.1</version>
                     <executions>
                         <execution>
                             <id>attach-sources</id>

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
     <version>1.1-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/src/main/java/com/stuntguy3000/lifxlansdk/util/TypeUtil.java
+++ b/src/main/java/com/stuntguy3000/lifxlansdk/util/TypeUtil.java
@@ -10,7 +10,7 @@
 
 package com.stuntguy3000.lifxlansdk.util;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;


### PR DESCRIPTION
Attempting to build the project currently using Java 11 or newer with `mvn clean package` fails with the following error:

```
 Compiling 100 source files to C:\Development\Gitprojects\seii-LIFX-LAN-SDK\target\classes
[INFO] /C:/Development/Gitprojects/seii-LIFX-LAN-SDK/src/main/java/com/stuntguy3000/lifxlansdk/handler/PacketHandler.java: Some input files use or override a deprecated API.
[INFO] /C:/Development/Gitprojects/seii-LIFX-LAN-SDK/src/main/java/com/stuntguy3000/lifxlansdk/handler/PacketHandler.java: Recompile with -Xlint:deprecation for details.
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] /C:/Development/Gitprojects/seii-LIFX-LAN-SDK/src/main/java/com/stuntguy3000/lifxlansdk/util/TypeUtil.java:[13,22] package javax.xml.bind does not exist
[INFO] 1 error
[INFO] -------------------------------------------------------------
```

This is because the `javax.xml.bind` namespace [ceased to exist in Java 11](https://www.oracle.com/java/technologies/javase/11-relnote-issues.html#JDK-8190378) and has instead moved to the `jakarta.xml.bind` namespace.

This PR adds the correct Jakarta dependency to the POM, as well as updating the single reference to it in the `TypeUtil` class.